### PR TITLE
Fixed the href links which before routed to wrong page (github's 404)

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@
                             <li>Radix Sort</li>
                             <li>Shell Sort</li>
                         </ul>
-                        <a href="https://github.com/TheAlgorithms/Algorithms-Explanation/tree/master/en/Sorting" class="algo-link">Learn More →</a>
+                        <a href="https://github.com/TheAlgorithms/Algorithms-Explanation/tree/master/en/Sorting%20Algorithms" class="algo-link">Learn More →</a>
                     </div>
                     <div class="algo-card">
                         <i class="fas fa-search"></i>
@@ -237,7 +237,7 @@
                             <li>Fibonacci Search</li>
                             <li>Ternary Search</li>
                         </ul>
-                        <a href="https://github.com/TheAlgorithms/Algorithms-Explanation/tree/master/en/Searching" class="algo-link">Learn More →</a>
+                        <a href="https://github.com/TheAlgorithms/Algorithms-Explanation/tree/master/en/Search%20Algorithms" class="algo-link">Learn More →</a>
                     </div>
                     <div class="algo-card">
                         <i class="fas fa-project-diagram"></i>


### PR DESCRIPTION
This Pull request fixes the improper route when clicked on button

before:
![image](https://github.com/user-attachments/assets/a427644e-f564-4e6d-82e3-7ab460f48585)
![image](https://github.com/user-attachments/assets/1e695b7c-9d3e-4f7c-9934-c71f17f51c3c)

now it routes to the correct pages :

![image](https://github.com/user-attachments/assets/ab9aa1a6-1d33-40be-b0eb-64524b5bbdcc)

This Pull request is ready to be merged.